### PR TITLE
Remove stray inclusion of sources jar

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,7 +92,6 @@ subprojects.filter { listOf("flink-core-kotlin", "flink-streaming-kotlin").conta
             publications {
                 register<MavenPublication>("bintray") {
                     from(components["java"])
-                    artifact(tasks["sourcesJar"])
                     artifact(tasks["docJar"])
                 }
             }


### PR DESCRIPTION
It's already included as part of the `java` component since it's
using Gradle's built in `withSourcesJar()`.